### PR TITLE
Allow using API key for uploads/downloads if apikey is set.

### DIFF
--- a/src/main/java/com/inedo/proget/api/ProGetApi.java
+++ b/src/main/java/com/inedo/proget/api/ProGetApi.java
@@ -196,8 +196,12 @@ public class ProGetApi implements Serializable {
 
         HttpEasy request = HttpEasy.request()
                 .path(path)
-                .authorization(config.user, config.password)
                 .urlParameters(feedName, groupName, packageName, version);
+        if(config.apiKey != null) {
+            request.header("X-ApiKey",config.apiKey);
+        } else {
+            request.authorization(config.user, config.password);
+        }
 
         if (latest) {
             request.query("latest");
@@ -211,11 +215,16 @@ public class ProGetApi implements Serializable {
     }
 
     public void uploadPackage(String feedName, File progetPackage) throws IOException {
-        HttpEasy.request()
+
+        HttpEasy request  = HttpEasy.request()
                 .path("upack/{feed-name}/upload")
-                .urlParameters(feedName)
-                .data(progetPackage, MediaType.ZIP)
-                .authorization(config.user, config.password)
-                .post();
+                .urlParameters( feedName)
+                .data(progetPackage, MediaType.ZIP);
+        if(config.apiKey != null) {
+            request.header("X-ApiKey",config.apiKey);
+        } else {
+            request.authorization(config.user, config.password);
+        }
+        request.post();
     }
 }

--- a/src/main/java/com/inedo/proget/jenkins/UploadPackageBuilder.java
+++ b/src/main/java/com/inedo/proget/jenkins/UploadPackageBuilder.java
@@ -171,7 +171,7 @@ public class UploadPackageBuilder extends Builder implements SimpleBuildStep {
             throw new AbortException("Please configure ProGet Plugin global settings");
         }
 
-        if (!GlobalConfig.isUserNameConfigured()) {
+        if (!GlobalConfig.isUserNameConfigured() && !GlobalConfig.isProGetApiKeyFieldConfigured()) {
             throw new AbortException("Please configure user credentials in ProGet Plugin global settings");
         }
 


### PR DESCRIPTION
Enables using APIKey for uploads and downloads rather than username/password authentication if the api key is set.

### Testing done

This has been tested locally and running for ~1yr on our local instance.

### Submitter checklist

Fixes - https://issues.jenkins.io/browse/JENKINS-67108

- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [ x] Please describe what you did
- [ x] Link to relevant issues in GitHub or Jira
- [ x] Link to relevant pull requests, esp. upstream and downstream changes
- [ x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
